### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,14 @@
     - vaultwarden_configure
     - vaultwarden_run
 
-- ansible.builtin.include_tasks: install.yml
+- name: Include the vaultwarden install playbook
+  ansible.builtin.include_tasks: install.yml
   become: true
   tags:
     - vaultwarden_install
 
-- ansible.builtin.include_tasks: configure.yml
+- name: Include the vaultwarden configure playbook
+  ansible.builtin.include_tasks: configure.yml
   become: true
   tags:
     - vaultwarden_configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,12 @@
     - vaultwarden_configure
     - vaultwarden_run
 
-- include: install.yml
+- ansible.builtin.include_tasks: install.yml
   become: true
   tags:
     - vaultwarden_install
 
-- include: configure.yml
+- ansible.builtin.include_tasks: configure.yml
   become: true
   tags:
     - vaultwarden_configure


### PR DESCRIPTION
with this we can get rid of the following message:
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. See https://docs.ansible.com/ansible-
core/2.14/user_guide/playbooks_reuse_includes.html for details. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```