### PR TITLE
Fix become on include_tasks tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,13 +13,17 @@
 
 - name: Include the vaultwarden install playbook
   ansible.builtin.include_tasks: install.yml
-  become: true
+  args:
+    apply:
+      become: true
   tags:
     - vaultwarden_install
 
 - name: Include the vaultwarden configure playbook
   ansible.builtin.include_tasks: configure.yml
-  become: true
+  args:
+    apply:
+      become: true
   tags:
     - vaultwarden_configure
 


### PR DESCRIPTION
Task keywords for included tasks need to be passed via args.apply:

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_tasks_module.html#parameter-apply


Fixes:
```
ERROR! 'become' is not a valid attribute for a TaskInclude

The error appears to be in '/home/hexa/.ansible/roles/jenstimmerman.vaultwarden/tasks/main.yml': line 14, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Include the vaultwarden install playbook
  ^ here
```