### PR TITLE
Update vaultwarden default to 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Builds, installs and configures [Vaultwarden](https://github.com/dani-garcia/vau
 | Variable | Description | Default value |
 | --- | --- | --- |
 | `vaultwarden_directory` | Where to install Vaultwarden | `/opt/vaultwarden` |
-| `vaultwarden_version` | Which version to install | `1.17.0` |
+| `vaultwarden_version` | Which version to install | `1.26.0` |
 | `vaultwarden_webvault` | Install the patched webvault | `true` |
-| `vaultwarden_webvault_version` | Version of the webvault to install | `2.16.1` |
+| `vaultwarden_webvault_version` | Version of the webvault to install | `2022.10.0` |
 | `vaultwarden_build_backend` | The database-type to compile for | *vaultwarden_version-specific(\*)* |
 | `vaultwarden_force_recompile` | Force recompile binary, (e.g. you switched backends on same server | `false` |
 | `vaultwarden_config` | Key-value environment variables for the Vaultwarden `.env` file | `{ DOMAIN: "https://{{ ansible_fqdn }}/" }` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 vaultwarden_directory: /opt/vaultwarden
-vaultwarden_version: 1.23.0
+vaultwarden_version: 1.26.0
 vaultwarden_webvault: true
-vaultwarden_webvault_version: 2.23.0
+vaultwarden_webvault_version: 2022.10.0
 vaultwarden_build_backend: "{{ 'sqlite,mysql,postgresql' if vaultwarden_version is version('1.17.0', '>=') else 'sqlite' }}"
 vaultwarden_force_recompile: false
 vaultwarden_config:


### PR DESCRIPTION
Update vaultwarden default to 1.26.0 and the web vault to 2022.10.0, the version mentioned in the release notes.

https://github.com/dani-garcia/vaultwarden/releases/tag/1.26.0
https://github.com/dani-garcia/vaultwarden/releases/tag/1.25.2
https://github.com/dani-garcia/vaultwarden/releases/tag/1.25.1
https://github.com/dani-garcia/vaultwarden/releases/tag/1.25.0
https://github.com/dani-garcia/vaultwarden/releases/tag/1.24.0
https://github.com/dani-garcia/vaultwarden/releases/tag/1.23.1

Tested and works for me.