### PR TITLE
Start after explicit database service units

### DIFF
--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description =  VaultWarden (https://github.com/dani-garcia/vaultwarden)
-After = network.target network-online.target dbus.service database.service
+After = network.target network-online.target dbus.service postgresql.service mysql.service
 Wants = network-online.target
 Requires = dbus.service
 


### PR DESCRIPTION
While many linux distros use mariadb in place of mysql, the unit name remains the same.