### PR TITLE
Bugfix for new permissions for the datadir

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -85,4 +85,4 @@
     state: directory
     owner: vaultwarden
     group: vaultwarden
-    mode: u=rw,go=
+    mode: u=rw,g=r,o=


### PR DESCRIPTION
The service crashes with the following message if the group vaultwarden has not at least the read permission for the vaultwarden_datadir.