### PR TITLE
Removing dbus dependency and sandboxing app

### DIFF
--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description =  VaultWarden (https://github.com/dani-garcia/vaultwarden)
-After = network.target
+After = network.target postgresql.service mysql.service
 
 [Service]
 WorkingDirectory = {{ vaultwarden_directory }}

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -5,8 +5,6 @@ Description =  VaultWarden (https://github.com/dani-garcia/vaultwarden)
 After = network.target postgresql.service mysql.service
 
 [Service]
-WorkingDirectory = {{ vaultwarden_directory }}
-EnvironmentFile={{ vaultwarden_directory }}/.env
 User = vaultwarden
 Group = vaultwarden
 ExecStart = {{ vaultwarden_directory }}/vaultwarden

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,9 +2,7 @@
 
 [Unit]
 Description =  VaultWarden (https://github.com/dani-garcia/vaultwarden)
-After = network.target network-online.target dbus.service postgresql.service mysql.service
-Wants = network-online.target
-Requires = dbus.service
+After = network.target
 
 [Service]
 WorkingDirectory = {{ vaultwarden_directory }}
@@ -12,6 +10,20 @@ EnvironmentFile={{ vaultwarden_directory }}/.env
 User = vaultwarden
 Group = vaultwarden
 ExecStart = {{ vaultwarden_directory }}/vaultwarden
+# Set reasonable connection and process limits
+LimitNOFILE=1048576
+LimitNPROC=64
+# Isolate vaultwarden from the rest of the system
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=strict
+WorkingDirectory = {{ vaultwarden_directory }}
+EnvironmentFile={{ vaultwarden_directory }}/.env
+ReadWriteDirectories={{ vaultwarden_directory }}
+# Allow vaultwarden to bind ports in the range of 0-1024
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy = multi-user.target

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -19,8 +19,6 @@ ProtectSystem=strict
 WorkingDirectory = {{ vaultwarden_directory }}
 EnvironmentFile={{ vaultwarden_directory }}/.env
 ReadWriteDirectories={{ vaultwarden_directory }}
-# Allow vaultwarden to bind ports in the range of 0-1024
-AmbientCapabilities=CAP_NET_BIND_SERVICE
 MemoryDenyWriteExecute=true
 
 [Install]


### PR DESCRIPTION
While I tried this role, handlers failed restarting vaultwarden service because of missing dbus package which seems to be a desktop related component. I suggest to discard it. I also added some sandboxing option base on my systemd knowledge and this service file: https://gist.github.com/tavinus/59c314f4ccd70879db7f11074eacb6cc 
