### PR TITLE
Install only needed dependencies

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,9 +25,16 @@
     owner: vaultwarden
     group: vaultwarden
 
+- name: Install required backend build-packages
+  ansible.builtin.package:
+    name: "{{ __vaultwarden_backend_build_packages[item] }}"
+    state: present
+  loop:
+    "{{ vaultwarden_build_backend | split(',') }}"
+
 - name: Install required build-packages
   ansible.builtin.package:
-    name: "{{ _vaultwarden_build_packages }}"
+    name: "{{ __vaultwarden_build_packages }}"
     state: present
 
 - name: Get rustup installer

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,12 +2,17 @@ __vaultwarden_build_packages:
   - build-essential
   - libssl-dev
   - pkg-config
+  - curl
 __vaultwarden_backend_build_packages:
-  # sqlite:
-  - sqlite3
-  # postgresql:
-  - libpq-dev
-  # mysql:
-  - libmariadb-dev-compat
-  - libmariadb-dev
-_vaultwarden_build_packages: "{{ [__vaultwarden_build_packages, __vaultwarden_backend_build_packages] | flatten(1) }}"
+  {
+    sqlite: [
+      sqlite3
+    ],
+    postgresql: [
+      libpq-dev
+    ],
+    mysql: [
+      libmariadb-dev-compat,
+      libmariadb-dev
+    ]
+  }

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -16,3 +16,4 @@ __vaultwarden_backend_build_packages:
       libmariadb-dev
     ]
   }
+  

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -16,4 +16,3 @@ __vaultwarden_backend_build_packages:
       libmariadb-dev
     ]
   }
-  

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,4 +1,4 @@
-_vaultwarden_build_packages:
+__vaultwarden_build_packages:
   - gcc
   - openssl-devel
   - pkg-config

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -3,7 +3,18 @@ _vaultwarden_build_packages:
   - openssl-devel
   - pkg-config
   - tar
-  - libpq-devel
-  - mariadb-devel
-  - mysql-libs
-  - sqlite-devel
+  - curl
+  
+ __vaultwarden_backend_build_packages:
+   {
+     sqlite: [
+       sqlite-devel
+     ],
+     postgresql: [
+       libpq-devel
+     ],
+     mysql: [
+       mariadb-devel
+       mysql-libs
+     ]
+   }

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -4,8 +4,8 @@ __vaultwarden_build_packages:
   - pkg-config
   - tar
   - curl
-  
- __vaultwarden_backend_build_packages:
+
+__vaultwarden_backend_build_packages:
    {
      sqlite: [
        sqlite-devel

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -14,7 +14,7 @@ __vaultwarden_build_packages:
        libpq-devel
      ],
      mysql: [
-       mariadb-devel
+       mariadb-devel,
        mysql-libs
      ]
    }

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -6,15 +6,15 @@ __vaultwarden_build_packages:
   - curl
 
 __vaultwarden_backend_build_packages:
-   {
-     sqlite: [
-       sqlite-devel
-     ],
-     postgresql: [
-       libpq-devel
-     ],
-     mysql: [
-       mariadb-devel,
-       mysql-libs
-     ]
-   }
+  {
+    sqlite: [
+      sqlite-devel
+    ],
+    postgresql: [
+      libpq-devel
+    ],
+    mysql: [
+      mariadb-devel,
+      mysql-libs
+    ]
+  }


### PR DESCRIPTION
I suggest to install only need dependencies for build. I would also suggest to remove them after build if not needed to run vaultwarden. This PR use vaultwarden_build_backend variable, which is suppose to be a coma separated list of backends to be included into the build, to select packages to be install.

I also suggest to added curl (could be wget) to the general package list to make the role working standalone